### PR TITLE
minor cleanups

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,18 +5,30 @@ WriteMakefile(
     NAME              => 'Net::Facebook::Oauth2',
     VERSION_FROM      => 'lib/Net/Facebook/Oauth2.pm', # finds $VERSION
     PREREQ_PM         => {
-        
-        LWP::UserAgent => 0,
-        URI::Escape => 0,
-        JSON::Any => 0
-        
+        'LWP::UserAgent' => 0,
+        'URI'            => 0,
+        'Carp'           => 0,
+        'URI::Escape'    => 0,
+        'JSON::Any'      => 0,
     },
     BUILD_REQUIRES => {
-        Test::Exception  => 0,
-        Test::MockObject => 0,
-        Test::MockModule => 0,
+        'Test::More'       => 0.88,
+        'Test::Exception'  => 0,
+        'Test::MockObject' => 0,
+        'Test::MockModule' => 0,
     },
     ($] >= 5.005 ?     ## Add these new keywords supported since 5.005
-      (ABSTRACT_FROM  => 'lib/Net/Facebook/Oauth2.pm', # retrieve abstract from module
-       AUTHOR         => 'Mahmoud A. Mehyar <mamod.mehyar@gmail.com>') : ()),
+      (
+          ABSTRACT_FROM  => 'lib/Net/Facebook/Oauth2.pm', # retrieve abstract from module
+          AUTHOR         => 'Mahmoud A. Mehyar <mamod.mehyar@gmail.com>'
+      )
+      : ()
+    ),
+    META_MERGE => {
+        resources => {
+            license    => 'http://dev.perl.org/licenses/',
+            bugtracker => 'https://github.com/mamod/Net-Facebook-Oauth2/issues',
+            repository => 'https://github.com/mamod/Net-Facebook-Oauth2',
+        },
+    },
 );

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -17,41 +17,41 @@ sub new {
     my ($class,%options) = @_;
     my $self = {};
     $self->{options} = \%options;
-    
+
     if (!$options{access_token}){
-        croak "You must provide your application id when construct new method\n Net::Facebook::Oauth2->new( application_id => '...' )" unless defined $self->{options}->{application_id};
-        croak "You must provide your application secret when construct new method\n Net::Facebook::Oauth2->new( application_secret => '...' )" unless defined $self->{options}->{application_secret};
+        croak "You must provide your application id in new()\nNet::Facebook::Oauth2->new( application_id => '...' )" unless defined $self->{options}->{application_id};
+        croak "You must provide your application secret in new()\nNet::Facebook::Oauth2->new( application_secret => '...' )" unless defined $self->{options}->{application_secret};
     }
-    
+
     $self->{browser}          = $options{browser} || LWP::UserAgent->new;
     $self->{access_token_url} = $options{access_token_url} || ACCESS_TOKEN_URL;
     $self->{authorize_url}    = $options{authorize_url} || AUTHORIZE_URL;
     $self->{access_token}     = $options{access_token};
     $self->{display}          = $options{display} || 'page'; ##other values popup and wab
-    
+
     return bless($self, $class);
 }
 
 sub get_authorization_url {
     my ($self,%params) = @_;
-    
+
     $params{callback} ||= $self->{options}->{callback};
     croak "You must pass a callback parameter with Oauth v2.0" unless defined $params{callback};
-    
+
     $params{display} = $self->{display} unless defined $params{display};
     $self->{options}->{callback} = $params{callback};
-    
+
     my $scope = join(",", @{$params{scope}}) if defined($params{scope});
-    
+
     my $url = $self->{authorize_url}
     ."?client_id="
     .uri_escape($self->{options}->{application_id})
     ."&redirect_uri="
     .uri_escape($params{callback});
-    
+
     $url .= "&scope=$scope" if $scope;
     $url .= "&display=".$params{display};
-    
+
     return $url;
 }
 
@@ -60,11 +60,11 @@ sub get_access_token {
     my ($self,%params) = @_;
     $params{callback} ||= $self->{options}->{callback};
     $params{code} ||= $self->{options}->{code};
-    
+
     croak "You must pass a code parameter with Oauth v2.0" unless defined $params{code};
     croak "You must pass callback URL" unless defined $params{callback};
     $self->{options}->{code} = $params{code};
-    
+
     ###generating access token URL
     my $getURL = $self->{access_token_url}
     ."?client_id="
@@ -74,9 +74,9 @@ sub get_access_token {
     ."&client_secret="
     .uri_escape($self->{options}->{application_secret})
     ."&code=$params{code}";
-    
+
     my $response = $self->{browser}->get($getURL);
-    
+
     ##got an error response from facebook
     ##die and display error message
     if (!$response->is_success){
@@ -84,18 +84,18 @@ sub get_access_token {
         my $error = $j->jsonToObj($response->content());
         croak "'" .$error->{error}->{type}. "'" . " " .$error->{error}->{message};
     }
-    
+
     ##everything is ok proccess response and extract access token
     my $file = $response->content();
     my ($access_token,$expires) = split(/&/, $file);
     my ($string,$token) = split(/=/, $access_token);
-    
+
     ###save access token
     if ($token){
         $self->{access_token} = $token;
         return $token;
     }
-    
+
     croak "can't get access token";
 }
 
@@ -106,10 +106,10 @@ sub get {
         $url .= $self->{_has_query} ? '&' : '?';
         $url .= "access_token=" . $self->{access_token};
     }
-    
+
     ##construct the new url
     my @array;
-    
+
     while ( my ($key, $value) = each(%{$params})){
         $value = uri_escape($value);
         push(@array, "$key=$value");
@@ -117,7 +117,7 @@ sub get {
 
     my $string = join('&', @array);
     $url .= "&".$string if $string;
-    
+
     my $response = $self->{browser}->get($url);
     my $content = $response->content();
     return $self->_content($content);
@@ -175,7 +175,7 @@ sub _has_access_token {
 }
 
 1;
-
+__END__
 =head1 NAME
 
 Net::Facebook::Oauth2 - a simple Perl wrapper around Facebook OAuth v2.0 protocol

--- a/t/Net-Facebook-Oauth2.t
+++ b/t/Net-Facebook-Oauth2.t
@@ -16,7 +16,7 @@ eval "use Test::Requires qw/Test::Exception Test::MockObject Test::MockModule/";
 if ($@){
     plan skip_all => 'Test::Requires required for testing';
 } else {
-    
+
     #had to re use??!
     use Test::Exception;
     use Test::MockObject;

--- a/t/accesstoken.t
+++ b/t/accesstoken.t
@@ -26,7 +26,7 @@ my $app = sub {
         my $query = $env->{QUERY_STRING};
         ok($query =~ /^limit=1000&access_token=OtherToken&message/);
     }
-    
+
     return [ 200, [ 'Content-Type' => 'text/plain' ], [ 'OK' ] ];
 };
 
@@ -44,12 +44,12 @@ test_tcp(
         $fb->post("$url?access_token=OtherToken", { message => 'Post request with access token' });
         $fb->get($url, { message => 'Get request without access token' });
         $fb->get("$url?access_token=OtherToken", { message => 'Get request with access token' });
-        
+
         ##new bug tests -- adding query to another query ?limit=100?access_token
         $fb->get("$url?limit=1000", { message => 'Get request with already set query' });
         $fb->get("$url", { message => 'Get request without already set query' });
         $fb->get("$url?limit=1000&access_token=OtherToken", { message => 'Get request with token and query' });
-        
+
     },
     server => sub {
         my $port = shift;


### PR DESCRIPTION
Hi! Me again :)

This small patch provides some minor cleanups:

* removed trailing whitespace;
* quoted dependencies on Makefile.PL for extra readability;
* added some resources (such as this repository) to the Makefile.PL (those will show up on MetaCPAN);
* Made some dependencies more explicit by adding them to the Makefile.PL;
* Did a small typo fix on the new() error messages;
* separated code from documentation with the `__END__` tag, which also makes compiling marginally faster.

Hope it helps!