### PR TITLE
travis badges with build information

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -2,6 +2,9 @@
 
 Net::Facebook::Oauth2 - a simple Perl wrapper around Facebook OAuth v2.0 protocol
 
+=for html
+<a href="https://travis-ci.org/mamod/Net-Facebook-Oauth2"><img src="https://travis-ci.org/mamod/Net-Facebook-Oauth2.svg?branch=master"></a>
+
 =head1 SYNOPSIS
 
     use CGI;

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -180,6 +180,9 @@ __END__
 
 Net::Facebook::Oauth2 - a simple Perl wrapper around Facebook OAuth v2.0 protocol
 
+=for html
+<a href="https://travis-ci.org/mamod/Net-Facebook-Oauth2"><img src="https://travis-ci.org/mamod/Net-Facebook-Oauth2.svg?branch=master"></a>
+
 =head1 SYNOPSIS
 
     use CGI;


### PR DESCRIPTION
Hi @mamod! I almost forgot: this patch puts the Travis-CI badge in both your README and the documentation that gets displayed on MetaCPAN.

If you want to put up some other banners like Coveralls.io and the CPAN Version Badge, check out http://onionstand.blogspot.com.br/2015/03/how-to-add-online-code-badges-to-your.html

Let me know if you have any questions or concerns :)

Cheers!