### PR TITLE
Facebook Graph v2 update

### DIFF
--- a/examples/CGI/facebook.pl
+++ b/examples/CGI/facebook.pl
@@ -16,100 +16,96 @@ as I can with no complication, plus Catalyst is awsome :)
 =cut
 
 sub facebook {
-    
+
     my $cgi = CGI->new;
-    
+
     my $fb = Net::Facebook::Oauth2->new(
         application_id => 'your_application_id',  ##get this from your facebook developers platform
         application_secret => 'your_application_secret', ##get this from your facebook developers platform
         callback => 'http://your-domain.com/callback',  ##Callback URL, facebook will redirect users after authintication
     );
-    
+
     my $url = $fb->get_authorization_url(
-        scope => ['offline_access','publish_stream'], ###pass scope/Extended Permissions params as an array telling facebook how you want to use this access
+        scope => ['offline_access','publish_stream', 'user_friends'], ###pass scope/Extended Permissions params as an array telling facebook how you want to use this access
         display => 'page' ## how to display authorization page, other options popup "to display as popup window" and wab "for mobile apps"
     );
-    
+
     ###scope/Extended Permissions description
     ##offline_access : Allow your application to edit profile while user is not online
     ##publish_stream : read write access
+    ##user_friends: list of user's friends
     ##you can find more about facebook scopes/Extended Permissions at
     ##http://developers.facebook.com/docs/authentication/permissions
-    
-    
+
     ##now redirect to the authorization page
     print $cgi->redirect($url);
-    
 }
 
 sub callback {
     ##this sub represent the callback block, where facebook will send users back upon authorization
-    
+
     my $cgi = CGI->new;
     my $fb = Net::Facebook::Oauth2->new(
         application_id => 'your_application_id',
         application_secret => 'your_application_secret',
         callback => 'http://your-domain.com/callback'
     );
-    
+
     ####We recieve "verifier" code parameter, now get access token
     ###you need to pass the verifier code to get access_token
     my $access_token = $fb->get_access_token(code => $cgi->param('code'));
-    
+
     ##that's it, now you have access_token of this user
     ###save this token in database or session to use later in your application
-    
     save_access_token($access_token);
-    
+
     print $cgi->header();
     print "Welcome";
-    
 }
 
 
 ###get information about this user from Facebook, use get method
 sub get {
-    
+
     my $cgi = CGI->new;
-    
+
     ###now any time you want to get information about user, just retrieve saved access_token of that use
     ###pass it to
     ###and call facebook Graph API URL
-    
+
     ###for example let's get friends list of that user
-    
     my $access_token = get_access_token('userid'); ###this is a demo, no real get_access_token sub here :P
-    
+
     my $fb = Net::Facebook::Oauth2->new(
         access_token => $access_token ##Load previous saved access token from session or database
     );
-    
+
     my $friends = $fb->get(
-        'https://graph.facebook.com/me/friends' ##Facebook friends list API URL
+        'https://graph.facebook.com/v2.2/me/friends' ##Facebook friends list API URL
     );
-    
+
     print $cgi->header();
     print $friends->as_json;
 }
 
 ###to post something to facebook use post method
 sub post {
-    
+
     my $cgi = CGI->new;
-    
+
     ###Lets post a message to the feed of the authorized user
     my $access_token = get_access_token('userid');
     my $fb = Net::Facebook::Oauth2->new(
         access_token => $access_token
     );
-    
+
     my $res = $fb->post(
-        'https://graph.facebook.com/me/feed', ###API URL
+        'https://graph.facebook.com/v2.2/me/feed', ###API URL
         {
             message => 'This is a post to my feed from Net::Facebook::Oauth2' ##hash of params/variables (param=>value)
         }
     );
-    
+
     print $cgi->header();
     print Dumper($res->as_hash); ##print response as perl hash
 }

--- a/examples/Catalyst/Facebook.pm
+++ b/examples/Catalyst/Facebook.pm
@@ -4,8 +4,8 @@ use strict;
 use warnings;
 use parent 'Catalyst::Controller';
 use Net::Facebook::Oauth2;
-    
-    
+
+
 =head1 DESCRIPTION
 
 this example shows you how to use Net::Facebook::Oauth2 with Catalyst,
@@ -18,137 +18,124 @@ facebook developer platfor for your application
 
 =cut
 
-    
-    
+
     sub index : Private {
-        
+
         my ( $self, $c ) = @_;
         my $params = $c->req->parameters;
-        
-        
+
         my $fb = Net::Facebook::Oauth2->new(
             application_id => 'your_application_id',  ##get this from your facebook developers platform
             application_secret => 'your_application_secret', ##get this from your facebook developers platform
             callback => 'http://localhost:3000/facebook',  ##Callback URL, facebook will redirect users after authintication
         );
-        
+
         #### first check if callback URL doesn't contain a verifier code  "code" parameter
         if (!$params->{code}){
-            
+
             ##there is no verifier code passed so let's create authorization URL and redirect to it
-            
             my $url = $fb->get_authorization_url(
-                scope => ['offline_access','publish_stream'], ###pass scope/Extended Permissions params as an array telling facebook how you want to use this access
+                scope => ['offline_access','publish_stream', 'user_friends'], ###pass scope/Extended Permissions params as an array telling facebook how you want to use this access
                 display => 'page' ## how to display authorization page, other options popup "to display as popup window" and wab "for mobile apps"
             );
-            
+
             ###scope/Extended Permissions description
             ##offline_access : Allow your application to edit profile while user is not online
             ##publish_stream : read write access
+            #user_friends: list of user's friends
             ##you can find more about facebook scopes/Extended Permissions at
             ##http://developers.facebook.com/docs/authentication/permissions
-            
             $c->res->redirect($url);
-            
         }
-        
         else {
-            
             ####second step, we recieved "verifier" code parameters, now get access token
             ###you need to pass the verifier code to get access_token
-            
             my $access_token = $fb->get_access_token( code => $params->{code} );
-            
+
             ###save this token in database or session
             $c->session->{access_token} =  $access_token;
             $c->res->body('Welcome from facebook');
         }
     }
-    
+
     ##get/post to facebook on the behalf of the authorized user
     ##first get this user information, login name, user profile URL
     sub get : Local {
-        
+
         my ( $self, $c ) = @_;
         my $params = $c->req->parameters;
-        
+
         my $fb = Net::Facebook::Oauth2->new(
             access_token => $c->session->{access_token} ##Load previous saved access token from session or database
         );
-        
+
         ##lets get list of friends for the authorized user
         my $info = $fb->get(
-            'https://graph.facebook.com/me' ##Facebook API URL
+            'https://graph.facebook.com/v2.2/me' ##Facebook API URL
         );
-        
+
         $c->res->body($info->as_json); ##as_json method will print response as json object
     }
-    
+
     ##example 2 - get friends list for this user
     sub get_friends : Local {
-        
+
         my ( $self, $c ) = @_;
         my $params = $c->req->parameters;
-        
+
         my $fb = Net::Facebook::Oauth2->new(
             access_token => $c->session->{access_token}
         );
-        
+
         ##lets get list of friends for the authorized user
         my $friends = $fb->get(
-            'https://graph.facebook.com/me/friends' ##Facebook 'list friend' Graph API URL
+            'https://graph.facebook.com/v2.2/me/friends' ##Facebook 'list friend' Graph API URL
         );
-        
+
         $c->res->body($friends->as_json);
     }
-    
+
     ###example 3 "get" search posts with some keyword
     sub search : Local {
         my ( $self, $c ) = @_;
         my $params = $c->req->parameters;
-        
+
         my $fb = Net::Facebook::Oauth2->new(
             access_token => $c->session->{access_token}
         );
-        
+
         ##lets search all posts with some keyword
         ##https://graph.facebook.com/search?q=watermelon&type=post
-        
+
         my $topics = $fb->get(
-            'https://graph.facebook.com/search', ##Facebook 'search' Graph API URL
+            'https://graph.facebook.com/v2.2/search', ##Facebook 'search' Graph API URL
             {
                 q => 'Keyword',
                 type => 'post'
             }
         );
-        
+
         $c->res->body($topics->as_json);
     }
-    
-    
+
     ####post to facebook example
     sub post : Local {
-        
+
         my ( $self, $c ) = @_;
         my $params = $c->req->parameters;
-        
+
         ###Lets post a message to the feed of the authorized user
-        
         my $fb = Net::Facebook::Oauth2->new(
             access_token => $c->session->{access_token}
         );
-        
-        
+
         my $res = $fb->post(
-            'https://graph.facebook.com/me/feed', ###API URL
+            'https://graph.facebook.com/v2.2/me/feed', ###API URL
             {
                 message => 'This is a post to my feed from Net::Facebook::Oauth2' ##hash of params/variables (param=>value)
             }
         );
-        
         $c->res->body($res->as_json);
-        
     }
-    
 
 1;

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -8,8 +8,8 @@ use URI::Escape;
 use JSON::MaybeXS;
 use Carp;
 
-use constant ACCESS_TOKEN_URL => 'https://graph.facebook.com/oauth/access_token';
-use constant AUTHORIZE_URL => 'https://www.facebook.com/dialog/oauth';
+use constant ACCESS_TOKEN_URL => 'https://graph.facebook.com/v2.2/oauth/access_token';
+use constant AUTHORIZE_URL    => 'https://www.facebook.com/v2.2/dialog/oauth';
 
 our $VERSION = '0.08';
 
@@ -222,7 +222,7 @@ Net::Facebook::Oauth2 - a simple Perl wrapper around Facebook OAuth v2.0 protoco
     );
     
     my $info = $fb->get(
-        'https://graph.facebook.com/me' ##Facebook API URL
+        'https://graph.facebook.com/v2.2/me' ##Facebook API URL
     );
     
     print $info->as_json;


### PR DESCRIPTION
Hey there! Me again :)

So! I have started this because Facebook has made changes to its Graph API. This module used the v1.x endpoints, which will be forcefully upgraded to v2.2 on April 30, 2015.

I have read through [Facebook's "how to upgrade" documentation](https://developers.facebook.com/docs/apps/upgrading) and think the only real changes that need to be made on this module is pointing to the new, versioned, endpoints. Applications and modules using this distribution (such as Dancer::Plugin::Auth::Facebook) will need to be updated too, otherwise they might stop working after April 30th and there's nothing we can do :(

Hope this helps!