### PR TITLE
update Facebook API to version 2.8

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,6 +16,10 @@ WriteMakefile(
         'Test::Exception'  => 0,
         'Test::MockObject' => 0,
         'Test::MockModule' => 0,
+        'Plack::Request'   => 0,
+        'Plack::Loader'    => 0,
+        'Test::Requires'   => 0,
+        'Test::TCP'        => 0,
     },
     ($] >= 5.005 ?     ## Add these new keywords supported since 5.005
       (

--- a/README.pod
+++ b/README.pod
@@ -47,7 +47,7 @@ Later on you can use it to communicate with Facebook on behalf of this user:
     );
 
     my $info = $fb->get(
-        'https://graph.facebook.com/v2.2/me'   # Facebook API URL
+        'https://graph.facebook.com/v2.8/me'   # Facebook API URL
     );
 
     print $info->as_json;

--- a/README.pod
+++ b/README.pod
@@ -19,7 +19,7 @@ Somewhere in your application's login process:
 
     # get the authorization URL for your application
     my $url = $fb->get_authorization_url(
-        scope   => [ 'public_profile', 'email', 'offline_access', 'publish_stream' ],
+        scope   => [ 'public_profile', 'email', 'user_posts', 'manage_pages' ],
         display => 'page'
     );
 
@@ -56,159 +56,8 @@ Later on you can use it to communicate with Facebook on behalf of this user:
 
 Net::Facebook::Oauth2 gives you a way to simply access FaceBook Oauth 2.0 protocol
 
-For more information please see example folder shipped with this Module
-
-=head1 SEE ALSO
-
-For more information about Facebook Oauth 2.0 API
-
-Please Check
-L<http://developers.facebook.com/docs/>
-
-get/post Facebook Graph API
-L<http://developers.facebook.com/docs/api>
-
-=head1 USAGE
-
-=head2 C<Net::Facebook::Oauth-E<gt>new( %args )>
-
-Pass args as hash. C<%args> are:
-
-=over 4
-
-=item * C<application_id >
-
-Your application id as you get from facebook developers platform
-when you register your application
-
-=item * C<application_secret>
-
-Your application secret id as you get from facebook developers platform
-when you register your application
-
-=back
-
-=head2 C<$fb-E<gt>get_authorization_url( %args )>
-
-Return an Authorization URL for your application, once you receive this
-URL redirect user there in order to authorize your application
-
-=over 4
-
-=item * C<scope>
-
-['offline_access','publish_stream',...]
-
-Array of Extended permissions as described by facebook Oauth2.0 API
-you can get more information about scope/Extended Permission from
-http://developers.facebook.com/docs/authentication/permissions
-
-Please note that requesting information other than C<public_profile>,
-C<email> and C<user_friends> B<will require your app to be reviewed by Facebook!>
-
-=item * C<callback>
-
-callback URL, where facebook will send users after they authorize
-your application
-
-=item * C<display>
-
-How to display Facebook Authorization page
-
-=over 4
-
-=item * C<page>
-
-This will display facebook authorization page as full page
-
-=item * C<popup>
-
-This option is useful if you want to popup authorization page
-as this option tell facebook to reduce the size of the authorization page
-
-=item * C<wab>
-
-From the name, for wab and mobile applications this option is the best
-facebook authorization page will fit there :)
-
-=back
-
-=back
-
-=head2 C<$fb-E<gt>get_access_token( %args )>
-
-Returns access_token string
-One arg to pass
-
-=over 4
-
-=item * C<code>
-
-This is the verifier code that facebook send back to your
-callback URL once user authorize your app, you need to capture
-this code and pass to this method in order to get access_token
-
-Verifier code will be presented with your callback URL as code
-parameter as the following
-
-http://your-call-back-url.com?code=234er7y6fdgjdssgfsd...
-
-When access token is returned you need to save it in a secure
-place in order to use it later in your application
-
-=back
-
-=head2 C<$fb-E<gt>get( $url,$args )>
-
-Send get request to facebook and returns response back from facebook
-
-=over 4
-
-=item * C<url>
-
-Facebook Graph API URL as string
-
-=item * C<$args>
-
-hashref of parameters to be sent with graph API URL if required
-
-=back
-
-The response returned can be formatted as the following
-
-=over 4
-
-=item * C<$responseE<gt>as_json>
-
-Returns response as json object
-
-=item * C<$responseE<gt>as_hash>
-
-Returns response as perl hashref
-
-=back
-
-For more information about facebook grapg API, please check
-http://developers.facebook.com/docs/api
-
-=head2 C<$fb-E<gt>post( $url,$args )>
-
-Send post request to facebook API, usually to post something
-
-=over 4
-
-=item * C<url>
-
-Facebook Graph API URL as string
-
-=item * C<$args>
-
-hashref of parameters to be sent with graph API URL
-
-=back
-
-For more information about facebook grapg API, please check
-http://developers.facebook.com/docs/api
+For more information please see example folder shipped with this Module, or refer
+to the L<full documentation|https://metacpan.org/pod/Net::Facebook::Oauth2>.
 
 =head1 INSTALLATION
 
@@ -243,7 +92,7 @@ Big Thanks To
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012-2015 by Mahmoud A. Mehyar
+Copyright (C) 2012-2016 by Mahmoud A. Mehyar
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.10.1 or,

--- a/examples/CGI/facebook.pl
+++ b/examples/CGI/facebook.pl
@@ -81,7 +81,7 @@ sub get {
     );
 
     my $friends = $fb->get(
-        'https://graph.facebook.com/v2.2/me/friends' ##Facebook friends list API URL
+        'https://graph.facebook.com/v2.8/me/friends' ##Facebook friends list API URL
     );
 
     print $cgi->header();
@@ -100,7 +100,7 @@ sub post {
     );
 
     my $res = $fb->post(
-        'https://graph.facebook.com/v2.2/me/feed', ###API URL
+        'https://graph.facebook.com/v2.8/me/feed', ###API URL
         {
             message => 'This is a post to my feed from Net::Facebook::Oauth2' ##hash of params/variables (param=>value)
         }

--- a/examples/CGI/facebook.pl
+++ b/examples/CGI/facebook.pl
@@ -25,17 +25,12 @@ sub facebook {
         callback => 'http://your-domain.com/callback',  ##Callback URL, facebook will redirect users after authintication
     );
 
-    my $url = $fb->get_authorization_url(
-        scope => ['offline_access','publish_stream', 'user_friends'], ###pass scope/Extended Permissions params as an array telling facebook how you want to use this access
-        display => 'page' ## how to display authorization page, other options popup "to display as popup window" and wab "for mobile apps"
-    );
-
-    ###scope/Extended Permissions description
-    ##offline_access : Allow your application to edit profile while user is not online
-    ##publish_stream : read write access
-    ##user_friends: list of user's friends
     ##you can find more about facebook scopes/Extended Permissions at
     ##http://developers.facebook.com/docs/authentication/permissions
+    my $url = $fb->get_authorization_url(
+        scope => ['user_posts','manage_pages', 'user_friends'], ###pass scope/Extended Permissions params as an array telling facebook how you want to use this access
+        display => 'page' ## how to display authorization page, other options popup "to display as popup window" and wab "for mobile apps"
+    );
 
     ##now redirect to the authorization page
     print $cgi->redirect($url);

--- a/examples/Catalyst/Facebook.pm
+++ b/examples/Catalyst/Facebook.pm
@@ -35,14 +35,10 @@ facebook developer platfor for your application
 
             ##there is no verifier code passed so let's create authorization URL and redirect to it
             my $url = $fb->get_authorization_url(
-                scope => ['offline_access','publish_stream', 'user_friends'], ###pass scope/Extended Permissions params as an array telling facebook how you want to use this access
+                scope => ['user_posts','manage_pages', 'user_friends'], ###pass scope/Extended Permissions params as an array telling facebook how you want to use this access
                 display => 'page' ## how to display authorization page, other options popup "to display as popup window" and wab "for mobile apps"
             );
 
-            ###scope/Extended Permissions description
-            ##offline_access : Allow your application to edit profile while user is not online
-            ##publish_stream : read write access
-            #user_friends: list of user's friends
             ##you can find more about facebook scopes/Extended Permissions at
             ##http://developers.facebook.com/docs/authentication/permissions
             $c->res->redirect($url);
@@ -71,7 +67,7 @@ facebook developer platfor for your application
 
         ##lets get list of friends for the authorized user
         my $info = $fb->get(
-            'https://graph.facebook.com/v2.2/me' ##Facebook API URL
+            'https://graph.facebook.com/v2.8/me' ##Facebook API URL
         );
 
         $c->res->body($info->as_json); ##as_json method will print response as json object
@@ -89,33 +85,10 @@ facebook developer platfor for your application
 
         ##lets get list of friends for the authorized user
         my $friends = $fb->get(
-            'https://graph.facebook.com/v2.2/me/friends' ##Facebook 'list friend' Graph API URL
+            'https://graph.facebook.com/v2.8/me/friends' ##Facebook 'list friend' Graph API URL
         );
 
         $c->res->body($friends->as_json);
-    }
-
-    ###example 3 "get" search posts with some keyword
-    sub search : Local {
-        my ( $self, $c ) = @_;
-        my $params = $c->req->parameters;
-
-        my $fb = Net::Facebook::Oauth2->new(
-            access_token => $c->session->{access_token}
-        );
-
-        ##lets search all posts with some keyword
-        ##https://graph.facebook.com/search?q=watermelon&type=post
-
-        my $topics = $fb->get(
-            'https://graph.facebook.com/v2.2/search', ##Facebook 'search' Graph API URL
-            {
-                q => 'Keyword',
-                type => 'post'
-            }
-        );
-
-        $c->res->body($topics->as_json);
     }
 
     ####post to facebook example
@@ -130,7 +103,7 @@ facebook developer platfor for your application
         );
 
         my $res = $fb->post(
-            'https://graph.facebook.com/v2.2/me/feed', ###API URL
+            'https://graph.facebook.com/v2.8/me/feed', ###API URL
             {
                 message => 'This is a post to my feed from Net::Facebook::Oauth2' ##hash of params/variables (param=>value)
             }

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -35,11 +35,11 @@ sub new {
         croak "You must provide your application secret in new()\nNet::Facebook::Oauth2->new( application_secret => '...' )" unless defined $self->{options}->{application_secret};
     }
 
-    $self->{browser}          = $options{browser} || LWP::UserAgent->new;
+    $self->{browser}          = $options{browser}          || LWP::UserAgent->new;
     $self->{access_token_url} = $options{access_token_url} || ACCESS_TOKEN_URL;
-    $self->{authorize_url}    = $options{authorize_url} || AUTHORIZE_URL;
+    $self->{authorize_url}    = $options{authorize_url}    || AUTHORIZE_URL;
+    $self->{display}          = $options{display}          || 'page'; ## other values popup and wab
     $self->{access_token}     = $options{access_token};
-    $self->{display}          = $options{display} || 'page'; ##other values popup and wab
 
     return bless($self, $class);
 }

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -220,7 +220,8 @@ Somewhere in your application's login process:
 Now redirect the user to this C<$url>.
 
 Once the user authorizes your application, Facebook will send him/her back
-to your application, on the C<callback> link provided above.
+to your application, on the C<callback> link provided above. PLEASE NOTE
+THAT YOU MUST PRE-AUTHORIZE YOUR CALLBACK URI ON FACEBOOK'S APP DASHBOARD.
 
 Inside that callback route, use the verifier code parameter that Facebook
 sends to get the access token:
@@ -267,11 +268,13 @@ L<http://developers.facebook.com/docs/api>
 
 =head2 C<Net::Facebook::Oauth-E<gt>new( %args )>
 
-Pass args as hash. C<%args> are:
+Returns a new object to handle user authentication.
+Pass arguments as a hash. The following arguments are I<REQUIRED>
+unless you're passing an access_token (see optional arguments below):
 
 =over 4
 
-=item * C<application_id >
+=item * C<application_id>
 
 Your application id as you get from facebook developers platform
 when you register your application

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -23,7 +23,7 @@ BEGIN {
 use constant ACCESS_TOKEN_URL => 'https://graph.facebook.com/v2.8/oauth/access_token';
 use constant AUTHORIZE_URL    => 'https://www.facebook.com/v2.8/dialog/oauth';
 
-our $VERSION = '0.09';
+our $VERSION = '0.10';
 
 sub new {
     my ($class,%options) = @_;
@@ -547,7 +547,7 @@ Big Thanks To
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012-2015 by Mahmoud A. Mehyar
+Copyright (C) 2012-2016 by Mahmoud A. Mehyar
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.10.1 or,

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -8,6 +8,18 @@ use URI::Escape;
 use JSON::MaybeXS;
 use Carp;
 
+BEGIN {
+    my @time = localtime;
+    if ($time[5] >= 118 && $time[4] > 8) {
+        warn "\n****************************************************************************\n"
+           . "[WARNING] This version of Net::Facebook::Oauth2 uses Facebook Graph API v2.8\n"
+           . "which is SCHEDULED FOR DEPRECATION on 5 October 2018. If this module\n"
+           . "(together with any associated code) is not updated, it may stop working!\n"
+           . "****************************************************************************\n"
+           ;
+    }
+};
+
 use constant ACCESS_TOKEN_URL => 'https://graph.facebook.com/v2.8/oauth/access_token';
 use constant AUTHORIZE_URL    => 'https://www.facebook.com/v2.8/dialog/oauth';
 
@@ -183,6 +195,9 @@ Net::Facebook::Oauth2 - a simple Perl wrapper around Facebook OAuth v2.0 protoco
 
 This module complies to Facebook Graph API version 2.8, the latest
 at the time of publication, B<< scheduled for deprecation on October 5th, 2018 >>.
+
+One month prior to that, using this version of Net::Facebook::Oauth2 will
+trigger a warning message.
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Hi there! Once again, thank you so much for creating Net::Facebook::Oauth2. I love its simplicity and straightforwardness :)

This Pull Request is meant to update the module to the latest version of Facebook's API (2.8). This is important because **the version used in this module (2.2) is [scheduled for deletion](https://developers.facebook.com/tools/api_versioning/226201254245474/) on the 30th of october** (this month! 😱)

To help you review it, this is what the new commits do:

* update all API requests from 2.2 to 2.8;
* update optional argument list on some methods, as per 2.8 specification;
* add some missing dependencies on the Makefile.PL (they were already been used by the tests);
* update all code samples under `/examples` to the new API - removing no longer existing paths (like `/search`) and updating scopes;
* trigger a warning when someone uses this module one month prior to [API 2.8 expiration date](https://developers.facebook.com/tools/api_versioning/226201254245474/) (2018-10-05);
* update documentation to reflect said changes;
* update the README to centralize all documentation on the POD;
* bump version number to 0.10;
* bump copyright year to 2016.

It might be worth it to say that **I have tested this on live Facebook accounts** and it works perfectly. As soon as this is merged, I will issue a Pull Request on Dancer::Plugin::Auth::Facebook for the same reason (but I need this merged first since it uses this module).

Please let me know if there is anything I can do to help you merge this as soon as possible. Like I said, if we do nothing this module will stop working in a few days - and I kinda need it :D 

Thanks!

garu