### PR TITLE
api 3.1 upgrade

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,13 @@
 Revision history for Perl module Net::Facebook::Oauth2.
 
+0.11
+    - update to Graph API v3.1
+    - allow custom API version setting (GH#15)
+    - new method debug_token() to fetch access token metadata from Facebook
+    - new method get_long_lived_token() to upgrade access tokens
+    - add missing dep
+    - documentation updates
+
 0.10  2016 2016-10-14
 	- Update to Graph API v2.8
 	- add missing deps

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,11 +5,12 @@ WriteMakefile(
     NAME              => 'Net::Facebook::Oauth2',
     VERSION_FROM      => 'lib/Net/Facebook/Oauth2.pm', # finds $VERSION
     PREREQ_PM         => {
-        'LWP::UserAgent' => 0,
-        'URI'            => 0,
-        'Carp'           => 0,
-        'URI::Escape'    => 0,
-        'JSON::MaybeXS'  => 0,
+        'LWP::UserAgent'       => 0,
+        'LWP::Protocol::https' => 0,
+        'URI'                  => 0,
+        'Carp'                 => 0,
+        'URI::Escape'          => 0,
+        'JSON::MaybeXS'        => 0,
     },
     BUILD_REQUIRES => {
         'Test::More'       => 0.88,

--- a/README.pod
+++ b/README.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-Net::Facebook::Oauth2 - a simple Perl wrapper around Facebook OAuth v2.0 protocol
+Net::Facebook::Oauth2 - a simple Perl wrapper around Facebook OAuth 2.0 protocol
 
 =for html
 <a href="https://travis-ci.org/mamod/Net-Facebook-Oauth2"><img src="https://travis-ci.org/mamod/Net-Facebook-Oauth2.svg?branch=master"></a>
@@ -19,14 +19,15 @@ Somewhere in your application's login process:
 
     # get the authorization URL for your application
     my $url = $fb->get_authorization_url(
-        scope   => [ 'public_profile', 'email', 'user_posts', 'manage_pages' ],
+        scope   => [ 'name', 'email', 'profile_picture' ],
         display => 'page'
     );
 
 Now redirect the user to this C<$url>.
 
 Once the user authorizes your application, Facebook will send him/her back
-to your application, on the C<callback> link provided above.
+to your application, on the C<callback> link provided above. PLEASE NOTE
+THAT YOU MUST PRE-AUTHORIZE YOUR CALLBACK URI ON FACEBOOK'S APP DASHBOARD.
 
 Inside that callback route, use the verifier code parameter that Facebook
 sends to get the access token:
@@ -35,10 +36,29 @@ sends to get the access token:
     # provides (e.g. $c->req->param('code'), $cgi->param('code'), etc)
     my $code = param('code');
 
-    my $access_token = $fb->get_access_token(code => $code);
+    use Try::Tiny;  # or eval {}, or whatever
+
+    my ($unique_id, $access_token);
+    try {
+        $access_token = $fb->get_access_token(code => $code); # <-- could die!
+
+        # Facebook tokens last ~2h, but you may upgrade them to ~60d if you want:
+        $access_token = $fb->get_long_lived_token( access_token => $access_token );
+
+        my $access_data = $fb->debug_token( input => $access_token );
+        if ($access_data && $access_data->{is_valid}) {
+            $unique_id = $access_data->{user_id};
+            # you could also check here for what scopes were granted to you
+            # by inspecting $access_data->{scopes}->@*
+        }
+    } catch {
+        # handle errors here!
+    };
 
 If you got so far, your user is logged! Save this access token in your
-database or session.
+database or session. As shown in the example above, Facebook also provides
+a unique I<user_id> for this token so you can associate it with a particular
+user of your app.
 
 Later on you can use it to communicate with Facebook on behalf of this user:
 
@@ -47,7 +67,7 @@ Later on you can use it to communicate with Facebook on behalf of this user:
     );
 
     my $info = $fb->get(
-        'https://graph.facebook.com/v2.8/me'   # Facebook API URL
+        'https://graph.facebook.com/v3.1/me'   # Facebook API URL
     );
 
     print $info->as_json;
@@ -92,7 +112,7 @@ Big Thanks To
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012-2016 by Mahmoud A. Mehyar
+Copyright (C) 2012-2018 by Mahmoud A. Mehyar
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.10.1 or,

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -301,7 +301,7 @@ sends to get the access token:
     try {
         $access_token = $fb->get_access_token(code => $code); # <-- could die!
 
-        # Facebook tokens last ~2h, but you may upgrade them to ~60d:
+        # Facebook tokens last ~2h, but you may upgrade them to ~60d if you want:
         $access_token = $fb->get_long_lived_token( access_token => $access_token );
 
         my $access_data = $fb->debug_token( input => $access_token );
@@ -338,9 +338,11 @@ C<< $info->{id} >>
 
 =head1 DESCRIPTION
 
-Net::Facebook::Oauth2 gives you a way to simply access FaceBook Oauth 2.0 protocol
+Net::Facebook::Oauth2 gives you a way to simply access FaceBook Oauth 2.0
+protocol.
 
-For more information please see example folder shipped with this Module
+The example folder contains some snippets you can look at, or for more
+information just keep reading :)
 
 =head1 SEE ALSO
 

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -8,7 +8,7 @@ use URI::Escape;
 use JSON::MaybeXS;
 use Carp;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 
 sub new {
     my ($class,%options) = @_;

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -278,7 +278,7 @@ Somewhere in your application's login process:
 
     # get the authorization URL for your application
     my $url = $fb->get_authorization_url(
-        scope   => [ 'name', 'email', 'profile_picture' ],
+        scope   => [ 'email' ],
         display => 'page'
     );
 

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -344,12 +344,17 @@ See C<display> under the C<get_authorization_url> method below.
 
 =item * C<authorize_url>
 
-Overrides the default (2.8) API endpoint for Facebook's oauth.
+Overrides the default (3.1) API endpoint for Facebook's oauth.
 Used mostly for testing new versions.
 
 =item * C<access_token_url>
 
-Overrides the default (2.8) API endpoint for Facebook's access token.
+Overrides the default (3.1) API endpoint for Facebook's access token.
+Used mostly for testing new versions.
+
+=item * C<debug_token_url>
+
+Overrides the default (3.1) API endpoint for Facebook's token information.
 Used mostly for testing new versions.
 
 =back

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -262,7 +262,7 @@ Net::Facebook::Oauth2 - a simple Perl wrapper around Facebook OAuth 2.0 protocol
 =head1 FACEBOOK GRAPH API VERSION
 
 This module complies to Facebook Graph API version 3.1, the latest
-at the time of publication, B<< scheduled for deprecation after July 26th, 2020 >>.
+at the time of publication, B<< scheduled for deprecation not sooner than July 26th, 2020 >>.
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Hi @mamod! Long time no see, hope you're doing well :)

Back in 2016 we set this module to API version v2.8, the latest at that time, which would deprecate... *now* 😱 😱 😱 

This PR updates all calls to v3.1, the new latest at that time, and is completely backwards compatible.

That said, I took the liberty to add two new public methods coming directly from Facebook's API:

* `debug_token()`, the new preferred method (by Facebook's documentation) to validate the access token;

* `get_long_lived_token()`, the only way to "upgrade" the default short-lived (~2h) access token to a long-lived (~60d) access token.

I also added the ability to pass an `api_version` to the constructor, so people can use new API versions without having to wait for a new version of this module. It also fixes #15 😄 

It looks like a big PR but it really isn't. It has two new isolated subs, the new api_version param, and `s/v2.8/v3.1/g`. The rest is just POD updates.

Hope this helps! I'm already using it in production, but it would be really nice to be able to fetch it directly from CPAN so if you could release it, it would be brilliant!

As usual, thank you so much for writing and maintaining this module. It's super useful! And if you have any questions or concerns, just let me know :)

Cheers!
garu