### PR TITLE
update Graph API to v4.0

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module Net::Facebook::Oauth2.
 
+0.12
+    - update to Graph API v4.0
+
 0.11
     - update to Graph API v3.1
     - allow custom API version setting (GH#15)

--- a/README.pod
+++ b/README.pod
@@ -112,7 +112,7 @@ Big Thanks To
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012-2018 by Mahmoud A. Mehyar
+Copyright (C) 2012-2019 by Mahmoud A. Mehyar
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.10.1 or,

--- a/README.pod
+++ b/README.pod
@@ -67,7 +67,7 @@ Later on you can use it to communicate with Facebook on behalf of this user:
     );
 
     my $info = $fb->get(
-        'https://graph.facebook.com/v3.1/me'   # Facebook API URL
+        'https://graph.facebook.com/v4.0/me'   # Facebook API URL
     );
 
     print $info->as_json;

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -8,7 +8,7 @@ use URI::Escape;
 use JSON::MaybeXS;
 use Carp;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 
 sub new {
     my ($class,%options) = @_;
@@ -694,7 +694,7 @@ Big Thanks To
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2012-2016 by Mahmoud A. Mehyar
+Copyright (C) 2012-2019 by Mahmoud A. Mehyar
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.10.1 or,

--- a/lib/Net/Facebook/Oauth2.pm
+++ b/lib/Net/Facebook/Oauth2.pm
@@ -15,7 +15,7 @@ sub new {
     my $self = {};
     $self->{options} = \%options;
 
-    my $api_version = defined $options{api_version} ? $options{api_version} : 'v3.1';
+    my $api_version = defined $options{api_version} ? $options{api_version} : 'v4.0';
 
     if (!defined $options{access_token}){
         croak "You must provide your application id in new()\nNet::Facebook::Oauth2->new( application_id => '...' )" unless defined $self->{options}->{application_id};
@@ -261,8 +261,8 @@ Net::Facebook::Oauth2 - a simple Perl wrapper around Facebook OAuth 2.0 protocol
 
 =head1 FACEBOOK GRAPH API VERSION
 
-This module complies to Facebook Graph API version 3.1, the latest
-at the time of publication, B<< scheduled for deprecation not sooner than July 26th, 2020 >>.
+This module complies to Facebook Graph API version 4.0, the latest
+at the time of publication, B<< scheduled for deprecation not sooner than August 3rd, 2021 >>.
 
 =head1 SYNOPSIS
 
@@ -327,7 +327,7 @@ of this user:
     );
 
     my $info = $fb->get(
-        'https://graph.facebook.com/v3.1/me'   # Facebook API URL
+        'https://graph.facebook.com/v4.0/me'   # Facebook API URL
     );
 
     print $info->as_json;
@@ -399,22 +399,22 @@ See C<display> under the C<get_authorization_url> method below.
 =item * C<api_version>
 
 Use this to replace the API version on all endpoints. The default
-value is 'v3.1'. Note that defining an api_version parameter together with
+value is 'v4.0'. Note that defining an api_version parameter together with
 C<authorize_url>, C<access_token_url> or C<debug_token_url> is a fatal error.
 
 =item * C<authorize_url>
 
-Overrides the default (3.1) API endpoint for Facebook's oauth.
+Overrides the default (4.0) API endpoint for Facebook's oauth.
 Used mostly for testing new versions.
 
 =item * C<access_token_url>
 
-Overrides the default (3.1) API endpoint for Facebook's access token.
+Overrides the default (4.0) API endpoint for Facebook's access token.
 Used mostly for testing new versions.
 
 =item * C<debug_token_url>
 
-Overrides the default (3.1) API endpoint for Facebook's token information.
+Overrides the default (4.0) API endpoint for Facebook's token information.
 Used mostly for testing new versions.
 
 =back


### PR DESCRIPTION
Hello! Thanks again for keeping this module up to date. This patch updates all routes to use the latest facebook API version (4.0), scheduled for deprecation on August 2021.

Thanks!